### PR TITLE
refactor: 設計書準拠のためExperiencesテーブルを修正

### DIFF
--- a/app/controllers/api/v1/experiences_controller.rb
+++ b/app/controllers/api/v1/experiences_controller.rb
@@ -85,7 +85,7 @@ module Api
       end
 
       def experience_params
-        params.require(:experience).permit(:title, :body, tags: [])
+        params.require(:experience).permit(:title, :body)
       end
 
       def serialize_experience(experience)
@@ -93,7 +93,6 @@ module Api
           id: experience.id,
           title: experience.title,
           body: experience.body,
-          tags: experience.tags || [],
           created_at: experience.created_at.iso8601,
           updated_at: experience.updated_at.iso8601
         }

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -1,14 +1,10 @@
 class Experience < ApplicationRecord
   # Validations
-  validates :title, presence: true, length: { maximum: 255 }
+  validates :title, presence: true, length: { maximum: 120 }
   validates :body, presence: true
-  validates :tags, length: { maximum: 10 }
-
-  validate :validate_tag_format
 
   # Scopes
   scope :recent, -> { order(created_at: :desc) }
-  scope :by_tag, ->(tag) { where("? = ANY(tags)", tag) }
 
   # Class methods
   def self.sorted_by(sort_param)
@@ -27,20 +23,6 @@ class Experience < ApplicationRecord
       order(title: :desc)
     else
       order(created_at: :desc)
-    end
-  end
-
-  private
-
-  def validate_tag_format
-    return unless tags.present?
-
-    tags.each_with_index do |tag, index|
-      if tag.blank?
-        errors.add(:tags, "#{index + 1}番目のタグが空です")
-      elsif tag.length > 50
-        errors.add(:tags, "#{index + 1}番目のタグが50文字を超えています")
-      end
     end
   end
 end

--- a/db/migrate/20250915201314_remove_tags_from_experiences.rb
+++ b/db/migrate/20250915201314_remove_tags_from_experiences.rb
@@ -1,0 +1,5 @@
+class RemoveTagsFromExperiences < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :experiences, :tags, :text
+  end
+end

--- a/db/migrate/20250915201400_change_experiences_title_limit.rb
+++ b/db/migrate/20250915201400_change_experiences_title_limit.rb
@@ -1,0 +1,5 @@
+class ChangeExperiencesTitleLimit < ActiveRecord::Migration[7.2]
+  def change
+    change_column :experiences, :title, :string, limit: 120, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_13_000001) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_15_201400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "experiences", force: :cascade do |t|
-    t.string "title", limit: 255, null: false
+    t.string "title", limit: 120, null: false
     t.text "body", null: false
-    t.text "tags", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_experiences_on_created_at"
-    t.index ["tags"], name: "index_experiences_on_tags", using: :gin
     t.index ["updated_at"], name: "index_experiences_on_updated_at"
   end
 end

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -254,19 +254,12 @@ components:
         title:
           type: string
           description: Experienceタイトル
-          maxLength: 255
+          maxLength: 120
           example: "製造業でのコスト削減体験"
         body:
           type: string
           description: Experience本文
           example: "工程改善により30%のコスト削減を実現した方法について共有します..."
-        tags:
-          type: array
-          description: タグ一覧
-          items:
-            type: string
-            maxLength: 50
-          example: ["コスト削減", "工程改善", "製造業"]
         created_at:
           type: string
           format: date-time
@@ -287,7 +280,7 @@ components:
         title:
           type: string
           description: Experienceタイトル
-          maxLength: 255
+          maxLength: 120
           minLength: 1
           example: "製造業でのコスト削減体験"
         body:
@@ -295,14 +288,6 @@ components:
           description: Experience本文
           minLength: 1
           example: "工程改善により30%のコスト削減を実現した方法について共有します..."
-        tags:
-          type: array
-          description: タグ一覧
-          items:
-            type: string
-            maxLength: 50
-          maxItems: 10
-          example: ["コスト削減", "工程改善", "製造業"]
 
     Pagination:
       type: object


### PR DESCRIPTION
# Pull Request

## 概要
データベース設計書に準拠するため、Experiencesテーブルからテスト用に追加された不適切な実装を削除し、正しい仕様に修正しました。

## 変更内容
- [ ] 新機能追加
- [ ] バグ修正
- [x] リファクタリング
- [ ] ドキュメント更新
- [ ] テスト追加/修正
- [x] 設定変更

## API仕様への影響
- [ ] **非破壊的変更** (既存のAPIクライアントに影響なし)
- [x] **破壊的変更** (/api/v2での実装または移行計画が必要)
- [ ] API仕様に変更なし

### 破壊的変更がある場合
- 影響範囲: tagsフィールドがAPIレスポンスから削除（フロントエンド側では未使用のため実質影響なし）
- 移行計画: フロントエンド側でtagsフィールドは実装しない方針のため移行不要
- 廃止スケジュール: 即座に廃止（設計書にない機能のため）

## テスト
- [x] 既存テストがすべて通る
- [ ] 新しいテストを追加済み
- [x] API契約検証が通る (committee-rails)
- [x] 手動テストを実施済み

## チェックリスト
- [x] コードレビュー用に適切なサイズにPRを分割
- [x] コミットメッセージが適切
- [x] ドキュメント更新が必要な場合は実施済み
- [ ] 環境変数の追加がある場合は`.env.example`を更新
- [x] データベースマイグレーションがある場合は本番環境での実行計画を検討済み

## 関連Issue
<\!-- 関連するIssue番号があれば記載 -->

## スクリーンショット
<\!-- UIに変更がある場合は Before/After のスクリーンショット -->
N/A (バックエンドAPI変更のため)

## 補足
- 設計書準拠のため、tagsカラム（PostgreSQL配列）を削除
- titleカラムの文字数制限を255→120文字に変更
- 今後は設計書の範囲内で段階的に機能を追加予定
- user_id、industry_id、occupation_id等は今後の実装で追加予定