### PR TITLE
fix: APIエンドポイントとOpenAPI仕様書を一貫性のあるexperience_postsに修正

### DIFF
--- a/app/controllers/api/v1/experience_posts_controller.rb
+++ b/app/controllers/api/v1/experience_posts_controller.rb
@@ -1,6 +1,6 @@
 module Api
   module V1
-    class ExperiencesController < ApplicationController
+    class ExperiencePostsController < ApplicationController
       include ErrorRenderable
 
       before_action :set_experience, only: [ :show, :update, :destroy ]
@@ -43,7 +43,7 @@ module Api
 
       # POST /api/v1/experiences
       def create
-        experience_params_hash = experience_params
+        experience_params_hash = experience_post_params
         experience = ExperiencePost.new(experience_params_hash)
 
         if experience.save
@@ -59,7 +59,7 @@ module Api
 
       # PUT /api/v1/experiences/1
       def update
-        experience_params_hash = experience_params
+        experience_params_hash = experience_post_params
 
         if @experience.update(experience_params_hash)
           render json: {
@@ -84,8 +84,8 @@ module Api
         @experience = ExperiencePost.find(params[:id])
       end
 
-      def experience_params
-        params.require(:experience).permit(:title, :body)
+      def experience_post_params
+        params.require(:experience_post).permit(:title, :body, :user_id, :industry_id, :occupation_id, :status, :published_at)
       end
 
       def serialize_experience(experience)

--- a/app/models/experience_post.rb
+++ b/app/models/experience_post.rb
@@ -2,6 +2,10 @@ class ExperiencePost < ApplicationRecord
   # Validations
   validates :title, presence: true, length: { maximum: 120 }
   validates :body, presence: true
+  validates :user_id, presence: true
+  validates :industry_id, presence: true
+  validates :occupation_id, presence: true
+  validates :status, presence: true, inclusion: { in: %w[draft published] }
 
   # Scopes
   scope :recent, -> { order(created_at: :desc) }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get :ping, to: "pings#show"  # TODO: 開発後に削除
-      resources :experiences, only: [ :index, :show, :create, :update, :destroy ]
+      resources :experience_posts, only: [ :index, :show, :create, :update, :destroy ]
     end
   end
 end

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,31 +1,31 @@
 openapi: 3.0.3
 info:
   title: Oshigoto Links API
-  description: エンジニア向け業界知識共有アプリケーション API
+  description: あらゆる「おしごと」体験を共有するプラットフォーム API
   version: 1.0.0
   contact:
     name: API Support
     url: https://github.com/motimotiosyo/oshigoto-links-backend
 servers:
-  - url: http://localhost:3000/api/v1
+  - url: http://localhost:3001/api/v1
     description: Development server
   - url: https://api.oshigoto-links.com/api/v1
-    description: Production server
+    description: Production server (未定)
 
 tags:
   - name: ExperiencePosts
-    description: 業界経験情報の管理
+    description: おしごと体験投稿の管理
 
 paths:
   /experience_posts:
     get:
       operationId: listExperiencePosts
-      summary: Experience一覧取得
-      description: Experience一覧をページネーション付きで取得
+      summary: おしごと体験投稿一覧取得
+      description: おしごと体験投稿一覧をページネーション付きで取得
       tags:
         - ExperiencePosts
-      security:
-        - bearerAuth: []
+      # security:
+      #   - bearerAuth: []  # TODO: 認証実装後に有効化
       parameters:
         - name: page
           in: query
@@ -84,12 +84,12 @@ paths:
     
     post:
       operationId: createExperiencePost
-      summary: Experience作成
-      description: 新しいExperienceを作成
+      summary: おしごと体験投稿作成
+      description: 新しいおしごと体験投稿を作成
       tags:
         - ExperiencePosts
-      security:
-        - bearerAuth: []
+      # security:
+      #   - bearerAuth: []  # TODO: 認証実装後に有効化
       requestBody:
         required: true
         content:
@@ -123,12 +123,12 @@ paths:
   /experience_posts/{id}:
     get:
       operationId: getExperiencePost
-      summary: Experience詳細取得
-      description: 指定されたIDのExperience詳細を取得
+      summary: おしごと体験投稿詳細取得
+      description: 指定されたIDのおしごと体験投稿詳細を取得
       tags:
         - ExperiencePosts
-      security:
-        - bearerAuth: []
+      # security:
+      #   - bearerAuth: []  # TODO: 認証実装後に有効化
       parameters:
         - name: id
           in: path
@@ -156,12 +156,12 @@ paths:
     
     put:
       operationId: updateExperiencePost
-      summary: Experience更新
-      description: 指定されたIDのExperienceを更新
+      summary: おしごと体験投稿更新
+      description: 指定されたIDのおしごと体験投稿を更新
       tags:
         - ExperiencePosts
-      security:
-        - bearerAuth: []
+      # security:
+      #   - bearerAuth: []  # TODO: 認証実装後に有効化
       parameters:
         - name: id
           in: path
@@ -204,12 +204,12 @@ paths:
     
     delete:
       operationId: deleteExperiencePost
-      summary: Experience削除
-      description: 指定されたIDのExperienceを削除
+      summary: おしごと体験投稿削除
+      description: 指定されたIDのおしごと体験投稿を削除
       tags:
         - ExperiencePosts
-      security:
-        - bearerAuth: []
+      # security:
+      #   - bearerAuth: []  # TODO: 認証実装後に有効化
       parameters:
         - name: id
           in: path
@@ -249,17 +249,17 @@ components:
       properties:
         id:
           type: integer
-          description: Experience ID
+          description: おしごと体験投稿 ID
           example: 1
         title:
           type: string
-          description: Experienceタイトル
+          description: おしごと体験投稿のタイトル
           maxLength: 120
-          example: "製造業でのコスト削減体験"
+          example: "在宅ワークでの集中力向上方法"
         body:
           type: string
-          description: Experience本文
-          example: "工程改善により30%のコスト削減を実現した方法について共有します..."
+          description: おしごと体験投稿の本文
+          example: "在宅ワークを始めてから集中力を保つのに苦労していましたが、ポモドーロテクニックを導入することで劇的に改善しました。"
         created_at:
           type: string
           format: date-time
@@ -279,15 +279,15 @@ components:
       properties:
         title:
           type: string
-          description: Experienceタイトル
+          description: おしごと体験投稿のタイトル
           maxLength: 120
           minLength: 1
-          example: "製造業でのコスト削減体験"
+          example: "在宅ワークでの集中力向上方法"
         body:
           type: string
-          description: Experience本文
+          description: おしごと体験投稿の本文
           minLength: 1
-          example: "工程改善により30%のコスト削減を実現した方法について共有します..."
+          example: "在宅ワークを始めてから集中力を保つのに苦労していましたが、ポモドーロテクニックを導入することで劇的に改善しました。25分集中→5分休憩のサイクルで作業効率が向上し、疲労感も軽減されました。"
 
     Pagination:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,17 +13,17 @@ servers:
     description: Production server
 
 tags:
-  - name: Experiences
+  - name: ExperiencePosts
     description: 業界経験情報の管理
 
 paths:
-  /experiences:
+  /experience_posts:
     get:
-      operationId: listExperiences
+      operationId: listExperiencePosts
       summary: Experience一覧取得
       description: Experience一覧をページネーション付きで取得
       tags:
-        - Experiences
+        - ExperiencePosts
       security:
         - bearerAuth: []
       parameters:
@@ -83,11 +83,11 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     
     post:
-      operationId: createExperience
+      operationId: createExperiencePost
       summary: Experience作成
       description: 新しいExperienceを作成
       tags:
-        - Experiences
+        - ExperiencePosts
       security:
         - bearerAuth: []
       requestBody:
@@ -120,13 +120,13 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-  /experiences/{id}:
+  /experience_posts/{id}:
     get:
-      operationId: getExperience
+      operationId: getExperiencePost
       summary: Experience詳細取得
       description: 指定されたIDのExperience詳細を取得
       tags:
-        - Experiences
+        - ExperiencePosts
       security:
         - bearerAuth: []
       parameters:
@@ -155,11 +155,11 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     
     put:
-      operationId: updateExperience
+      operationId: updateExperiencePost
       summary: Experience更新
       description: 指定されたIDのExperienceを更新
       tags:
-        - Experiences
+        - ExperiencePosts
       security:
         - bearerAuth: []
       parameters:
@@ -203,11 +203,11 @@ paths:
           $ref: '#/components/responses/InternalServerError'
     
     delete:
-      operationId: deleteExperience
+      operationId: deleteExperiencePost
       summary: Experience削除
       description: 指定されたIDのExperienceを削除
       tags:
-        - Experiences
+        - ExperiencePosts
       security:
         - bearerAuth: []
       parameters:


### PR DESCRIPTION
# Pull Request

## 概要
テーブル名変更に伴い、APIエンドポイントとOpenAPI仕様書を一貫性のあるexperience_postsに修正し、実際のアプリ要件に合わせて更新しました。

## 変更内容
- [ ] 新機能追加
- [x] バグ修正
- [x] リファクタリング
- [x] ドキュメント更新
- [ ] テスト追加/修正
- [x] 設定変更

## API仕様への影響
- [x] **破壊的変更** (/api/v2での実装または移行計画が必要)
- [ ] **非破壊的変更** (既存のAPIクライアントに影響なし)
- [ ] API仕様に変更なし

### 破壊的変更がある場合
- 影響範囲: APIエンドポイントが/api/v1/experiences → /api/v1/experience_postsに変更
- 移行計画: フロントエンド側で新しいエンドポイントURLに変更
- 廃止スケジュール: 即座に変更（一貫性確保のため）

## 修正内容詳細

### 1. APIエンドポイント修正
- **ルーティング**: `/api/v1/experience_posts`に変更
- **コントローラー**: `ExperiencePostsController`に改名
- **パラメータ**: `experience_post_params`に変更
- **新カラム対応**: user_id, industry_id, occupation_id, status, published_atをパラメータ許可に追加

### 2. OpenAPI仕様書修正
- **パス**: `/experience_posts`に変更
- **タグ**: `ExperiencePosts`に変更
- **operationId**: 全て`experiencePost`系に変更
- **サーバーURL**: localhost:3001（正しいバックエンドポート）に修正

### 3. アプリ要件への対応
- **説明**: 「エンジニア向け業界知識共有」→「あらゆる『おしごと』体験を共有」に修正
- **サンプルデータ**: 製造業特化→在宅ワーク等の一般的な内容に変更
- **認証設定**: 未実装状況に合わせてコメントアウト

### 4. モデル修正
- **バリデーション**: 新しいカラム（user_id, industry_id, occupation_id, status）の制約追加
- **status制限**: draft/published のみ許可

## テスト
- [x] 既存テストがすべて通る
- [ ] 新しいテストを追加済み
- [ ] API契約検証が通る (committee-rails) ※関連テーブル作成後に対応予定
- [x] 手動テストを実施済み

## チェックリスト
- [x] コードレビュー用に適切なサイズにPRを分割
- [x] コミットメッセージが適切
- [x] ドキュメント更新が必要な場合は実施済み
- [ ] 環境変数の追加がある場合は`.env.example`を更新
- [x] データベースマイグレーションがある場合は本番環境での実行計画を検討済み

## 関連Issue
フロントエンドから/api/v1/experience_postsが見つからないエラーを解決

## 今後の予定
- 次のPRでusers, industries, occupationsテーブルを作成予定
- 正式なリレーション設定とテストデータ作成を実施予定

## 補足
- この修正によりテーブル名、モデル名、APIエンドポイント、OpenAPI仕様書の一貫性が確保された
- フロントエンド側は `/api/v1/experience_posts` を `localhost:3001` で呼び出すことで正常動作
- 関連テーブル作成は別PRで実施予定